### PR TITLE
API connection to get total tweets count once

### DIFF
--- a/Moises/app.py
+++ b/Moises/app.py
@@ -231,6 +231,13 @@ def get_all_texts():
         return jsonify("Method is not allowed"), 405
     else:
         return ClassifiedController().getAllTexts()
+
+@app.route('/classified/count', methods=['GET'])
+def get_text_count():
+    if request.method != 'GET':
+        return jsonify("Method is not allowed"), 405
+    else:
+        return ClassifiedController().getTextCount()
 @app.route('/classified/page', methods=['GET'])
 def get_texts_by_page():
     if request.method != 'GET':

--- a/Moises/controller/classified_text_controller.py
+++ b/Moises/controller/classified_text_controller.py
@@ -25,6 +25,11 @@ class ClassifiedController:
         author = [self.build_texts_dict(row) for row in author_list]
         return jsonify(author), 200
 
+    def getTextCount(self):
+        dao = ClassifiedDAO()
+        total_count = dao.getTextCount()
+        return jsonify({'total': total_count}), 200
+
     def getTextsById(self, text_id):
         dao = ClassifiedDAO()
         classified_text = dao.getTextById(text_id)

--- a/Moises/model/classified.py
+++ b/Moises/model/classified.py
@@ -20,6 +20,14 @@ class ClassifiedDAO:
         author_list = [row for row in cur]
         return author_list
 
+    def getTextCount(self):
+        cur = self.db.connection.cursor()
+        query = """SELECT count(*)
+                            FROM classified_text"""
+        cur.execute(query)
+        total_count = cur.fetchone()[0]
+        return total_count
+
     def getTextById(self, text_id):
         try:
             cur = self.db.connection.cursor()


### PR DESCRIPTION
Set up API connection to not hardcode the total amount of items, as this number will surely increase once this is connected to the cluster. 